### PR TITLE
Add doctest and fix issues in example

### DIFF
--- a/python/vesin-torch/vesin/torch/metatensor/_neighbors.py
+++ b/python/vesin-torch/vesin/torch/metatensor/_neighbors.py
@@ -57,19 +57,21 @@ class NeighborList:
         ...     types=torch.tensor([8, 1, 1]),
         ...     pbc=torch.ones(3, dtype=bool),
         ... )
-        >>> options = NeighborListOptions(cutoff=4.0, full_list=True)
+        >>> options = NeighborListOptions(cutoff=4.0, full_list=True, strict=False)
         >>> calculator = NeighborList(options, length_unit="Angstrom")
         >>> neighbors = calculator.compute(system)
         >>> neighbors
         TensorBlock
-            samples (54): ['first_atom', 'second_atom', 'cell_shift_a', 'cell_shift_b',
-        ...    'cell_shift_c']
+            samples (18): ['first_atom', 'second_atom', 'cell_shift_a', 'cell_shift_b', 'cell_shift_c']
             components (3): ['xyz']
             properties (1): ['distance']
             gradients: None
-        >>> # The returned TensorBlock can then be registered with the system
+        <BLANKLINE>
+
+        The returned TensorBlock can then be registered with the system
+
         >>> system.add_neighbor_list(options, neighbors)
-        """
+        """  # noqa: E501
 
         if not torch.jit.is_scripting():
             if not _HAS_METATENSOR:

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,9 @@ changedir = python/vesin
 commands =
     pytest {posargs}
 
+    # Enable when doc examples exist; pytest fails if no tests exist
+    # pytest --doctest-modules --pyargs vesin
+
 [testenv:torch-tests]
 passenv = *
 description = Run the tests of the vesin-torch Python package
@@ -54,6 +57,7 @@ commands =
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py
 
     pytest {posargs}
+    pytest --doctest-modules --pyargs vesin.torch
 
 
 [testenv:cxx-tests]


### PR DESCRIPTION
The `strict` option was missing in the metatensor example. I fixed this and added doctests to prevent these in the future.