### PR TITLE
Fix benchmark script

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -43,8 +43,6 @@ def setup_torch_nl_cpu(atoms, cutoff):
     pos, cell, pbc, batch, n_atoms = torch_nl.ase2data(
         [atoms], device=torch.device("cpu")
     )
-    print(pos.dtype)
-    raise 44
     return cutoff, pos, cell, pbc, batch
 
 


### PR DESCRIPTION
Running the `benchmark.py` script fails with the following error:
```
  File "/home/rmeli/git/work/vesin/benchmarks/benchmark.py", line 47, in setup_torch_nl_cpu                                                                            
    raise 44                                                                                                                                                           
TypeError: exceptions must derive from BaseException
```

The `print` function makes me believe the `raise 44` statement was added for manual debugging and made it to the source code. Removing it allows to run the benchmarking script successfully.