### PR TITLE
Properly set symbol visibility, take 2

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -24,7 +24,6 @@ if (VESIN_MAIN_PROJECT)
     endif()
 endif()
 
-option(BUILD_SHARED_LIBS "Build shared libraries instead of static ones" OFF)
 option(VESIN_INSTALL "Install Vesin's headers and libraries" ${VESIN_MAIN_PROJECT})
 
 add_subdirectory(vesin)
@@ -42,21 +41,17 @@ target_link_libraries(vesin_torch PUBLIC torch)
 
 target_include_directories(vesin_torch PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+    $<INSTALL_INTERFACE:include>
 )
 
 target_compile_features(vesin_torch PUBLIC cxx_std_17)
-target_compile_definitions(vesin_torch PRIVATE VESIN_EXPORTS)
 
+target_compile_definitions(vesin_torch PRIVATE VESIN_TORCH_EXPORTS)
 set_target_properties(vesin_torch PROPERTIES
     # hide non-exported symbols by default
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
 )
-
-if (BUILD_SHARED_LIBS)
-    target_compile_definitions(vesin_torch PUBLIC VESIN_SHARED)
-endif()
 
 #------------------------------------------------------------------------------#
 # Installation configuration

--- a/torch/include/vesin_torch.hpp
+++ b/torch/include/vesin_torch.hpp
@@ -3,6 +3,26 @@
 
 #include <torch/data.h>
 
+// clang-format off
+#if defined(VESIN_TORCH_EXPORTS)
+    #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+        #define VESIN_TORCH_API __attribute__((visibility("default")))
+    #elif defined(_MSC_VER)
+        #define VESIN_TORCH_API __declspec(dllexport)
+    #else
+        #define VESIN_TORCH_API
+    #endif
+#else
+    #if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+        #define VESIN_TORCH_API __attribute__((visibility("default")))
+    #elif defined(_MSC_VER)
+        #define VESIN_TORCH_API __declspec(dllimport)
+    #else
+        #define VESIN_TORCH_API
+    #endif
+#endif
+// clang-format on
+
 struct VesinNeighborList;
 
 namespace vesin_torch {
@@ -13,7 +33,7 @@ class NeighborListHolder;
 using NeighborList = torch::intrusive_ptr<NeighborListHolder>;
 
 /// Neighbor list calculator compatible with TorchScript
-class NeighborListHolder: public torch::CustomClassHolder {
+class VESIN_TORCH_API NeighborListHolder: public torch::CustomClassHolder {
 public:
     /// Create a new calculator with the given `cutoff`.
     ///

--- a/vesin/CMakeLists.txt
+++ b/vesin/CMakeLists.txt
@@ -32,14 +32,22 @@ set(VESIN_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/vesin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpu_cell_list.cpp
 )
+
+# create two targets: `vesin` is the main one, while `vesin_objects` will
+# be used by language bindings to embed vesin inside another (SHARED) library
+add_library(vesin ${VESIN_SOURCES})
 add_library(vesin_objects OBJECT ${VESIN_SOURCES})
 
 target_include_directories(vesin_objects PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-target_compile_features(vesin_objects PRIVATE cxx_std_17)
+target_include_directories(vesin PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
+target_compile_features(vesin_objects PRIVATE cxx_std_17)
 set_target_properties(vesin_objects PROPERTIES
     # hide non-exported symbols by default
     CXX_VISIBILITY_PRESET hidden
@@ -48,20 +56,16 @@ set_target_properties(vesin_objects PROPERTIES
     EXCLUDE_FROM_ALL ON
 )
 
-target_compile_definitions(vesin_objects PRIVATE VESIN_EXPORTS)
-if (BUILD_SHARED_LIBS)
-    target_compile_definitions(vesin_objects PUBLIC VESIN_SHARED)
-endif()
-
-add_library(vesin)
-target_link_libraries(vesin vesin_objects)
-
-target_include_directories(vesin PUBLIC
-    $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+target_compile_features(vesin PRIVATE cxx_std_17)
+set_target_properties(vesin PROPERTIES
+    # hide non-exported symbols by default
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
 )
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(vesin PUBLIC VESIN_SHARED)
+    target_compile_definitions(vesin PRIVATE VESIN_EXPORTS)
 endif()
 
 if (VESIN_BUILD_TESTS)


### PR DESCRIPTION
- vesin symbols are no longer visible from libvesin_torch
- libvesin_torch symbols are now properly exported