### PR TITLE
Always build vesin with -fPIC

### DIFF
--- a/vesin/CMakeLists.txt
+++ b/vesin/CMakeLists.txt
@@ -66,6 +66,7 @@ set_target_properties(vesin PROPERTIES
     # hide non-exported symbols by default
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
+    POSITION_INDEPENDENT_CODE ON
 )
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
It is not an issue for pure static binaries, and allows to link a static vesin inside a shared library.

Fix #70 