### PR TITLE
Use a larger max_pairs on CUDA for bigger cutoff

### DIFF
--- a/python/vesin/tests/test_cupy.py
+++ b/python/vesin/tests/test_cupy.py
@@ -261,8 +261,8 @@ def test_max_pairs():
     points = cp.array(np.random.default_rng(0).random((100, 3), dtype=dtype) * 3.0)
 
     message = (
-        "The number of neighbor pairs exceeds the maximum capacity of 30720 "
-        "\\(max_pairs_per_point=256; n_points=100\\). Consider reducing the "
+        "The number of neighbor pairs exceeds the maximum capacity of 12800 "
+        "\\(max_pairs_per_point=128; n_points=100\\). Consider reducing the "
         "cutoff distance, or explicitly setting VESIN_CUDA_MAX_PAIRS_PER_POINT as "
         "an environment variable."
     )
@@ -277,7 +277,7 @@ def test_max_pairs():
 
     os.environ["VESIN_CUDA_MAX_PAIRS_PER_POINT"] = "10"
     message = (
-        "The number of neighbor pairs exceeds the maximum capacity of 1200 "
+        "The number of neighbor pairs exceeds the maximum capacity of 1000 "
         "\\(max_pairs_per_point=10; n_points=100\\). Consider reducing the "
         "cutoff distance, or explicitly setting VESIN_CUDA_MAX_PAIRS_PER_POINT as "
         "an environment variable."

--- a/vesin/src/vesin_cuda.cpp
+++ b/vesin/src/vesin_cuda.cpp
@@ -470,7 +470,10 @@ void vesin::cuda::neighbors(
     }
 
     auto* extras = vesin::cuda::get_cuda_extras(&neighbors);
-    size_t max_pairs_per_point = VESIN_DEFAULT_CUDA_MAX_PAIRS_PER_POINT;
+    size_t max_pairs_per_point = std::max(
+        static_cast<size_t>(VESIN_CUDA_AT_LEAST_PAIRS_PER_POINT),
+        static_cast<size_t>(std::ceil(std::pow(options.cutoff, 3)))
+    );
 
     if (extras->allocated_device_id != device_id) {
         // first switch to previous device
@@ -508,26 +511,25 @@ void vesin::cuda::neighbors(
             max_pairs_per_point = static_cast<size_t>(parsed_max_pairs_per_point);
         }
 
-        auto max_pairs = static_cast<size_t>(1.2 * static_cast<double>(n_points * max_pairs_per_point));
-        extras->max_pairs = max_pairs;
+        extras->max_pairs = n_points * max_pairs_per_point;
 
-        CUDART_SAFE_CALL(CUDART_INSTANCE.cudaMalloc((void**)&neighbors.pairs, sizeof(size_t) * max_pairs * 2));
+        CUDART_SAFE_CALL(CUDART_INSTANCE.cudaMalloc((void**)&neighbors.pairs, sizeof(size_t) * extras->max_pairs * 2));
 
         if (options.return_shifts) {
             CUDART_SAFE_CALL(
-                CUDART_INSTANCE.cudaMalloc((void**)&neighbors.shifts, sizeof(int32_t) * max_pairs * 3)
+                CUDART_INSTANCE.cudaMalloc((void**)&neighbors.shifts, sizeof(int32_t) * extras->max_pairs * 3)
             );
         }
 
         if (options.return_distances) {
             CUDART_SAFE_CALL(
-                CUDART_INSTANCE.cudaMalloc((void**)&neighbors.distances, sizeof(double) * max_pairs)
+                CUDART_INSTANCE.cudaMalloc((void**)&neighbors.distances, sizeof(double) * extras->max_pairs)
             );
         }
 
         if (options.return_vectors) {
             CUDART_SAFE_CALL(
-                CUDART_INSTANCE.cudaMalloc((void**)&neighbors.vectors, sizeof(double) * max_pairs * 3)
+                CUDART_INSTANCE.cudaMalloc((void**)&neighbors.vectors, sizeof(double) * extras->max_pairs * 3)
             );
         }
 

--- a/vesin/src/vesin_cuda.hpp
+++ b/vesin/src/vesin_cuda.hpp
@@ -6,10 +6,13 @@
 namespace vesin {
 namespace cuda {
 
-#ifndef VESIN_DEFAULT_CUDA_MAX_PAIRS_PER_POINT
-/// @brief Default maximum number of pairs per point on the GPU (can be
-/// overridden).
-#define VESIN_DEFAULT_CUDA_MAX_PAIRS_PER_POINT 256
+#ifndef VESIN_CUDA_AT_LEAST_PAIRS_PER_POINT
+/// Default value for the number of pairs per points in the CUDA implementation.
+/// Unless `VESIN_CUDA_MAX_PAIRS_PER_POINT` is set in the environement, the
+/// maximal number of pairs is `n_points *
+/// max(VESIN_CUDA_AT_LEAST_PAIRS_PER_POINT, cutoff^3)`. This can be overriden
+/// at compile time.
+#define VESIN_CUDA_AT_LEAST_PAIRS_PER_POINT 128
 #endif
 
 /// @brief Buffers for cell list-based neighbor search


### PR DESCRIPTION
In most of my tests, `n_pairs / (n_atoms * cutoff^3)` was around 0.1-0.4, up to 0.7 for the diamond example. @frostedoyster had another case where this ratio was closer to 0.88, so setting it to 1 here should be a good enough default in most cases.