### PR TITLE
Simplify compiling with the fortran interface

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -145,11 +145,18 @@ Installation
 
         .. code-block:: cmake
 
+            # make sure to enable CXX as a language in this project to
+            # link the C++ standard library
+            project(your-project LANGUAGES CXX Fortran)
+
             set(VESIN_FORTRAN ON CACHE BOOL "Build the vesin_fortran library")
 
             add_subdirectory(vesin)
-            # or use fetch_content
+            # or use fetch_content, see above
             FetchContent_xxx(...)
+
+            # link to vesin_fortran
+            target_link_libraries(your-fortran-target vesin_fortran)
 
 
     .. tab-item:: |logo-c| |logo-cxx| Single file

--- a/fortran/CMakeLists.txt
+++ b/fortran/CMakeLists.txt
@@ -31,7 +31,7 @@ add_subdirectory(vesin)
 
 add_library(vesin_fortran src/vesin.f90 src/cdef.f90)
 
-target_link_libraries(vesin_fortran PRIVATE vesin_objects)
+target_link_libraries(vesin_fortran PUBLIC vesin)
 set_target_properties(vesin_fortran PROPERTIES Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
 
 target_include_directories(vesin_fortran PUBLIC

--- a/fortran/tests/CMakeLists.txt
+++ b/fortran/tests/CMakeLists.txt
@@ -1,6 +1,4 @@
 add_executable(fortran-tests tests.f90)
 target_link_libraries(fortran-tests vesin_fortran)
 
-set_target_properties(fortran-tests PROPERTIES LINKER_LANGUAGE Fortran)
-
 add_test(fortran-tests fortran-tests)


### PR DESCRIPTION
Link the `vesin_fortran` target with `vesin` library directly with `PUBLIC` to propagate the dependencies when `-DBUILD_SHARED_LIBS=ON` is used.

Originally, if one wanted to link a fortran target, it has to be done with `vesin`, `vesin_fortran`, and `stdc++`:
```cmake
target_link_libraries( my-fortran-target vesin vesin_fortran stdc++ )
```
With the proposed changes the dependency of `vesin_fortran` on `vesin` is propagated, so no matter the value of `-DBUILD_SHARED_LIBS`, the link is just to `vesin_fortran` and `stdc++`:
```cmake
target_link_libraries( my-fortran-target vesin_fortran stdc++ )
```