### PR TITLE
Faster sorting of the list of pairs

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -128,6 +128,19 @@ def pymatgen_run(structure, cutoff):
     return structure.get_neighbor_list(cutoff)
 
 
+def setup_vesin(atoms, cutoff):
+    calculator = vesin.NeighborList(
+        cutoff=cutoff,
+        full_list=True,
+        sorted=False,
+    )
+    return calculator, atoms
+
+
+def vesin_run(calculator, atoms):
+    return calculator.compute(atoms.positions, atoms.cell, atoms.pbc, quantities="ijSd")
+
+
 def determine_super_cell(max_cell_repeat, max_log_size_delta, max_cell_ratio):
     """
     Determine which super cells to include. We want equally spaced number of atoms in
@@ -308,8 +321,8 @@ for cutoff in [3, 6, 12]:
 
         # VESIN
         timing = benchmark(
-            setup_ase_like,
-            vesin.ase_neighbor_list,
+            setup_vesin,
+            vesin_run,
             super_cell,
             cutoff,
         )

--- a/fortran/src/cdef.f90
+++ b/fortran/src/cdef.f90
@@ -55,8 +55,9 @@ module vesin_c
         !! and `j -> i` pairs) or a half list (include only `i -> j`)?
         logical(c_bool) :: full
 
-        !> Should the neighbor list be sorted? If yes, the returned pairs will be
-        !! sorted using lexicographic order.
+        !> Should the neighbor list be sorted? If `.true.`, the returned pairs
+        !! will be sorted by the first point index (`i`). The order of the second
+        !! point index (`j`) and shifts in the list of pairs is unspecified.
         logical(c_bool) :: sorted = .false.
 
         !> Which algorithm to use for the calculation

--- a/fortran/src/vesin.f90
+++ b/fortran/src/vesin.f90
@@ -85,8 +85,9 @@ contains
         !! and `j -> i` pairs) or a half list (include only `i -> j`)?
         logical, intent(in) :: full
 
-        !> Should the neighbor list be sorted? If yes, the returned pairs will be
-        !! sorted using lexicographic order.
+        !> Should the neighbor list be sorted?  If `.true.`, the returned pairs
+        !! will be sorted by the first index (`i`). The order of the second
+        !! index (`j`) and shifts in the list of pairs is unspecified.
         logical, intent(in), optional :: sorted
 
         !> Algorithm to use for the neighbor list calculation (one of
@@ -125,8 +126,9 @@ contains
         !! and `j -> i` pairs) or a half list (include only `i -> j`)?
         logical, intent(in) :: full
 
-        !> Should the neighbor list be sorted? If yes, the returned pairs will be
-        !! sorted using lexicographic order.
+        !> Should the neighbor list be sorted?  If `.true.`, the returned pairs
+        !! will be sorted by the first point index (`i`). The order of the second
+        !! point index (`j`) and shifts in the list of pairs is unspecified.
         logical, intent(in), optional :: sorted
 
         !> Algorithm to use for the neighbor list calculation (one of

--- a/fortran/tests/tests.f90
+++ b/fortran/tests/tests.f90
@@ -14,6 +14,8 @@ program vesin_test
     real :: expected_vectors(3, 10)
     real :: expected_distances(10)
 
+    integer :: i
+
 
     points(:, 1) = [0.0, 0.0, 0.0]
     points(:, 2) = [0.0, 1.3, 1.3]
@@ -48,32 +50,32 @@ program vesin_test
 
     if (neighbor_list%length /= 10) call print_and_exit("wrong number of pairs")
 
-    expected_pairs = reshape([0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1], [2, 10])
+    expected_pairs = reshape([0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1], [2, 10])
     expected_distances = [&
-        3.20000004, 3.2000000, 3.2000000, 2.6870059, 2.3021729, &
-        2.30217293, 1.8384776, 3.2000000, 3.2000000, 3.2000000  &
+        2.6870059, 2.3021729, 2.3021729, 1.8384775, 3.2000000, &
+        3.2000000, 3.2000000, 3.2000000, 3.2000000, 3.2000000  &
     ]
     expected_shifts = reshape([ &
-        0, 0, 1,    &
-        0, 1, 0,    &
-        1, 0, 0,    &
-        0, -1, -1,  &
-        0, -1, 0,   &
-        0, 0, -1,   &
-        0, 0, 0,    &
-        0, 0, 1,    &
-        0, 1, 0,    &
-        1, 0, 0     &
+        0, -1, -1, &
+        0, -1,  0, &
+        0,  0, -1, &
+        0,  0,  0, &
+        0,  0,  1, &
+        0,  1,  0, &
+        1,  0,  0, &
+        0,  0,  1, &
+        0,  1,  0, &
+        1,  0,  0  &
     ], [3, 10])
 
     expected_vectors = reshape([ &
+        0.0000000, -1.9000000, -1.9000000, &
+        0.0000000, -1.9000000,  1.2999999, &
+        0.0000000,  1.2999999, -1.9000000, &
+        0.0000000,  1.2999999,  1.2999999, &
         0.0000000,  0.0000000,  3.2000000, &
         0.0000000,  3.2000000,  0.0000000, &
         3.2000000,  0.0000000,  0.0000000, &
-        0.0000000, -1.9000000, -1.9000000, &
-        0.0000000, -1.9000000,  1.3000000, &
-        0.0000000,  1.3000000, -1.9000000, &
-        0.0000000,  1.3000000,  1.3000000, &
         0.0000000,  0.0000000,  3.2000000, &
         0.0000000,  3.2000000,  0.0000000, &
         3.2000000,  0.0000000,  0.0000000  &
@@ -97,6 +99,18 @@ program vesin_test
 
     call neighbor_list%compute(points, box, periodic=[.true., .true., .true.], status=ierr)
     if (ierr /= 0) call print_and_exit(neighbor_list%errmsg)
+
+    print *, "shifts: ["
+    do i=1,neighbor_list%length
+        print *, neighbor_list%shifts(:, i)
+    end do
+    print *, "]"
+
+    print *, "vectors: ["
+    do i=1,neighbor_list%length
+        print *, neighbor_list%vectors(:, i)
+    end do
+    print *, "]"
 
     if (neighbor_list%length /= 10) call print_and_exit("wrong number of pairs")
 

--- a/python/vesin/tests/test_cupy.py
+++ b/python/vesin/tests/test_cupy.py
@@ -266,13 +266,12 @@ def test_sorted_output(algorithm):
     calculator = NeighborList(
         cutoff=cutoff, full_list=False, sorted=True, algorithm=algorithm
     )
-    i, j, S = calculator.compute(
-        points=points, box=box, periodic=True, quantities="ijS"
+    (sorted_i,) = calculator.compute(
+        points=points, box=box, periodic=True, quantities="i"
     )
 
-    ijS = cp.asnumpy(cp.concatenate((i.reshape(-1, 1), j.reshape(-1, 1), S), axis=1))
-    sorted_ijS = ijS[np.lexsort(np.flip(ijS, axis=1).T)]
-    assert np.array_equal(ijS, sorted_ijS)
+    sorted_i = cp.asnumpy(sorted_i)
+    assert np.all(sorted_i == np.sort(sorted_i))
 
 
 @pytest.mark.parametrize("dtype", [cp.float32, cp.float64])

--- a/python/vesin/tests/test_numpy.py
+++ b/python/vesin/tests/test_numpy.py
@@ -69,52 +69,27 @@ def test_sorting():
     atoms = ase.io.read(f"{CURRENT_DIR}/data/diamond.xyz")
 
     calculator = NeighborList(cutoff=2.0, full_list=True, sorted=False)
-    i, j = calculator.compute(
-        points=atoms.positions, box=atoms.cell[:], periodic=True, quantities="ij"
+    (unsorted_i,) = calculator.compute(
+        points=atoms.positions, box=atoms.cell[:], periodic=True, quantities="i"
     )
-    unsorted_ij = np.concatenate((i.reshape(-1, 1), j.reshape(-1, 1)), axis=1)
-    assert not np.all(unsorted_ij[np.lexsort((j, i))] == unsorted_ij)
+    assert not np.all(np.sort(unsorted_i) == unsorted_i)
 
     calculator = NeighborList(cutoff=2.0, full_list=True, sorted=True)
-    i, j = calculator.compute(
-        points=atoms.positions, box=atoms.cell[:], periodic=True, quantities="ij"
+    (sorted_i,) = calculator.compute(
+        points=atoms.positions, box=atoms.cell[:], periodic=True, quantities="i"
     )
-
-    sorted_ij = np.concatenate((i.reshape(-1, 1), j.reshape(-1, 1)), axis=1)
-    assert np.all(sorted_ij[np.lexsort((j, i))] == sorted_ij)
+    assert np.all(sorted_i == np.sort(sorted_i))
 
     # check that unsorted is not already sorted by chance
-    assert not np.all(sorted_ij == unsorted_ij)
+    assert not np.all(sorted_i == unsorted_i)
 
     # https://github.com/Luthaf/vesin/issues/34
     atoms = ase.io.read(f"{CURRENT_DIR}/data/Cd2I4O12.xyz")
     calculator = NeighborList(cutoff=5.0, full_list=True, sorted=True)
-    i, j = calculator.compute(
-        points=atoms.positions, box=atoms.cell[:], periodic=True, quantities="ij"
+    (sorted_i,) = calculator.compute(
+        points=atoms.positions, box=atoms.cell[:], periodic=True, quantities="i"
     )
-    sorted_ij = np.concatenate((i.reshape(-1, 1), j.reshape(-1, 1)), axis=1)
-    assert np.all(sorted_ij[np.lexsort((j, i))] == sorted_ij)
-
-
-def test_sorting_tie_break_on_shifts():
-    points = np.array([[0.0, 0.0, 0.0]], dtype=np.float64)
-    box = np.array(
-        [
-            [0.5, 0.0, 0.0],
-            [0.0, 0.5, 0.0],
-            [0.0, 0.0, 0.5],
-        ],
-        dtype=np.float64,
-    )
-
-    calculator = NeighborList(cutoff=0.6, full_list=False, sorted=True)
-    i, j, S = calculator.compute(
-        points=points, box=box, periodic=True, quantities="ijS"
-    )
-
-    ijS = np.concatenate((i.reshape(-1, 1), j.reshape(-1, 1), S), axis=1)
-    # sorted by i, then j, then shifts
-    assert np.all(ijS[np.lexsort(np.flip(ijS, axis=1).T)] == ijS)
+    assert np.all(sorted_i == np.sort(sorted_i))
 
 
 def test_errors():

--- a/python/vesin/vesin/_ase.py
+++ b/python/vesin/vesin/_ase.py
@@ -19,6 +19,13 @@ def ase_neighbor_list(quantities, a, cutoff, self_interaction=False, max_nbins=0
     - :py:class:`ase.Atoms` with mixed periodic boundary conditions
     - giving ``cutoff`` as a dictionary
 
+    .. note::
+
+        The returned neighbor list will be sorted by the first point index (``i``) since
+        this is what ASE does. This takes some time, so if you don't need the neighbor
+        list to be sorted, you can get better performance by using
+        :py:class:`NeighborList` directly.
+
     :param quantities: quantities to output from the neighbor list. Supported are
         ``"i"``, ``"j"``, ``"d"``, ``"D"``, and ``"S"`` with the same meaning as in ASE.
     :param a: :py:class:`ase.Atoms` instance

--- a/python/vesin/vesin/_neighbors.py
+++ b/python/vesin/vesin/_neighbors.py
@@ -81,8 +81,9 @@ class NeighborList:
         :param cutoff: spherical cutoff for this neighbor list
         :param full_list: should we return each pair twice (as ``i-j`` and ``j-i``) or
             only once
-        :param sorted: Should vesin sort the returned pairs in lexicographic order
-            (sorting both ``i`` and then ``j`` at constant ``i``)?
+        :param sorted: Should the neighbor list be sorted? If ``True``, the returned
+            pairs will be sorted by the first point index (``i``). The order of the
+            second point index (``j``) and shifts in the list of pairs is unspecified.
         :param algorithm: algorithm to use when computing the neighbor list. One of
             ``"auto"``, ``"brute_force"``, or ``"cell_list"``.
         """

--- a/python/vesin_torch/vesin/torch/_neighbors.py
+++ b/python/vesin_torch/vesin/torch/_neighbors.py
@@ -17,8 +17,9 @@ class NeighborList:
         :param cutoff: spherical cutoff for this neighbor list
         :param full_list: should we return each pair twice (as ``i-j`` and ``j-i``) or
             only once
-        :param sorted: Should vesin sort the returned pairs in lexicographic order
-            (sorting both ``i`` and then ``j`` at constant ``i``)?
+        :param sorted: Should the neighbor list be sorted? If ``True``, the returned
+            pairs will be sorted by the first point index (``i``). The order of the
+            second point index (``j``) and shifts in the list of pairs is unspecified.
         :param algorithm: algorithm to use when computing the neighbor list. One of
             ``"auto"``, ``"brute_force"``, or ``"cell_list"``.
         """

--- a/torch/include/vesin_torch.hpp
+++ b/torch/include/vesin_torch.hpp
@@ -39,10 +39,12 @@ public:
     ///
     /// @param cutoff the spherical cutoff radius
     /// @param full_list whether pairs should be included twice in the output
-    ///                  (both as `i-j` and `j-i`) or only once
-    /// @param sorted whether pairs should be sorted in the output
+    ///        (both as `i-j` and `j-i`) or only once
+    /// @param sorted whether pairs should be sorted by the first point index in
+    //         the output. The order of the second point index (``j``) and
+    //         shifts in the list of pairs is unspecified.
     /// @param algorithm the algorithm to use for neighbor list calculation. One
-    ///                  of `"auto"`, `"brute_force"`, or `"cell_list"`.
+    ///        of `"auto"`, `"brute_force"`, or `"cell_list"`.
     NeighborListHolder(double cutoff, bool full_list, bool sorted = false, std::string algorithm = "auto");
     ~NeighborListHolder();
 

--- a/vesin/include/vesin.h
+++ b/vesin/include/vesin.h
@@ -52,8 +52,9 @@ struct VesinOptions {
     /// Should the returned neighbor list be a full list (include both `i -> j`
     /// and `j -> i` pairs) or a half list (include only `i -> j`)?
     bool full;
-    /// Should the neighbor list be sorted? If yes, the returned pairs will be
-    /// sorted using lexicographic order.
+    /// Should the neighbor list be sorted? If `true`, the returned pairs will
+    /// be sorted by the first point index (`i`). The order of the second point
+    /// index (`j`) and shifts in the list of pairs is unspecified.
     bool sorted;
     /// Which algorithm to use for the calculation
     VesinAlgorithm algorithm;

--- a/vesin/src/cpu_cell_list.cpp
+++ b/vesin/src/cpu_cell_list.cpp
@@ -479,80 +479,75 @@ void GrowableNeighborList::sort() {
         compare_pairs(this->neighbors.pairs, this->neighbors.shifts, options.return_shifts)
     );
 
-    // step 2: permute all data according to the sorted indices.
-    int64_t cur = 0;
-    int64_t is_sorted_up_to = 0;
-    // data in `from` should go to `cur`
-    auto from = indices[cur];
+    // step 2: move all data according to the sorted indices.
+    auto* sorted_pairs = alloc<size_t, 2>(nullptr, 0, this->capacity);
 
-    size_t tmp_pair[2] = {0};
-    double tmp_distance = 0;
-    double tmp_vector[3] = {0};
-    int32_t tmp_shift[3] = {0};
+    int32_t (*sorted_shifts)[3] = nullptr;
+    if (options.return_shifts) {
+        sorted_shifts = alloc<int32_t, 3>(nullptr, 0, this->capacity);
+    }
 
-    while (cur < this->length()) {
-        // move data from `cur` to temporary
-        std::swap(tmp_pair, this->neighbors.pairs[cur]);
-        if (options.return_distances) {
-            std::swap(tmp_distance, this->neighbors.distances[cur]);
-        }
-        if (options.return_vectors) {
-            std::swap(tmp_vector, this->neighbors.vectors[cur]);
-        }
+    double* sorted_distances = nullptr;
+    if (options.return_distances) {
+        sorted_distances = alloc<double>(nullptr, 0, this->capacity);
+    }
+
+    double (*sorted_vectors)[3] = nullptr;
+    if (options.return_vectors) {
+        sorted_vectors = alloc<double, 3>(nullptr, 0, this->capacity);
+    }
+
+    if (
+        (sorted_pairs == nullptr) ||
+        (options.return_shifts && sorted_shifts == nullptr) ||
+        (options.return_distances && sorted_distances == nullptr) ||
+        (options.return_vectors && sorted_vectors == nullptr)
+    ) {
+        std::free(sorted_pairs);
+        std::free(sorted_shifts);
+        std::free(sorted_distances);
+        std::free(sorted_vectors);
+        throw std::runtime_error("could not allocate memory for sorting neighbor list");
+    }
+
+    for (size_t i = 0; i < this->neighbors.length; i++) {
+        auto from = static_cast<size_t>(indices[i]);
+        sorted_pairs[i][0] = this->neighbors.pairs[from][0];
+        sorted_pairs[i][1] = this->neighbors.pairs[from][1];
+
         if (options.return_shifts) {
-            std::swap(tmp_shift, this->neighbors.shifts[cur]);
+            sorted_shifts[i][0] = this->neighbors.shifts[from][0];
+            sorted_shifts[i][1] = this->neighbors.shifts[from][1];
+            sorted_shifts[i][2] = this->neighbors.shifts[from][2];
         }
 
-        from = indices[cur];
-        do {
-            if (from == cur) {
-                // permutation loop of a single entry, i.e. this value stayed
-                // where is already was
-                break;
-            }
-            // move data from `from` to `cur`
-            std::swap(this->neighbors.pairs[cur], this->neighbors.pairs[from]);
-            if (options.return_distances) {
-                std::swap(this->neighbors.distances[cur], this->neighbors.distances[from]);
-            }
-            if (options.return_vectors) {
-                std::swap(this->neighbors.vectors[cur], this->neighbors.vectors[from]);
-            }
-            if (options.return_shifts) {
-                std::swap(this->neighbors.shifts[cur], this->neighbors.shifts[from]);
-            }
-
-            // mark this spot as already visited
-            indices[cur] = -1;
-
-            // update the indices
-            cur = from;
-            from = indices[cur];
-        } while (indices[from] != -1);
-
-        // we found a full loop of permutation, we can put tmp into `cur`
-        std::swap(this->neighbors.pairs[cur], tmp_pair);
         if (options.return_distances) {
-            std::swap(this->neighbors.distances[cur], tmp_distance);
+            sorted_distances[i] = this->neighbors.distances[from];
         }
+
         if (options.return_vectors) {
-            std::swap(this->neighbors.vectors[cur], tmp_vector);
+            sorted_vectors[i][0] = this->neighbors.vectors[from][0];
+            sorted_vectors[i][1] = this->neighbors.vectors[from][1];
+            sorted_vectors[i][2] = this->neighbors.vectors[from][2];
         }
-        if (options.return_shifts) {
-            std::swap(this->neighbors.shifts[cur], tmp_shift);
-        }
+    }
 
-        indices[cur] = -1;
+    std::free(this->neighbors.pairs);
+    this->neighbors.pairs = sorted_pairs;
 
-        // look for the next loop of permutation
-        cur = is_sorted_up_to;
-        while (indices[cur] == -1) {
-            cur += 1;
-            is_sorted_up_to += 1;
-            if (cur == this->length()) {
-                break;
-            }
-        }
+    if (options.return_shifts) {
+        std::free(this->neighbors.shifts);
+        this->neighbors.shifts = sorted_shifts;
+    }
+
+    if (options.return_distances) {
+        std::free(this->neighbors.distances);
+        this->neighbors.distances = sorted_distances;
+    }
+
+    if (options.return_vectors) {
+        std::free(this->neighbors.vectors);
+        this->neighbors.vectors = sorted_vectors;
     }
 }
 

--- a/vesin/src/cpu_cell_list.cpp
+++ b/vesin/src/cpu_cell_list.cpp
@@ -3,7 +3,6 @@
 #include <cstring>
 
 #include <algorithm>
-#include <new>
 #include <numeric>
 #include <tuple>
 
@@ -310,11 +309,13 @@ static array_ptr<scalar_t, N> alloc(array_ptr<scalar_t, N> ptr, size_t size, siz
     auto* new_ptr = reinterpret_cast<scalar_t(*)[N]>(std::realloc(ptr, new_size * sizeof(scalar_t[N])));
 
     if (new_ptr == nullptr) {
-        throw std::bad_alloc();
+        return nullptr;
     }
 
+#ifndef NDEBUG
     // initialize with a bit pattern that maps to NaN for double
     std::memset(new_ptr + size, 0b11111111, (new_size - size) * sizeof(scalar_t[N]));
+#endif
 
     return new_ptr;
 }
@@ -324,11 +325,13 @@ static scalar_t* alloc(scalar_t* ptr, size_t size, size_t new_size) {
     auto* new_ptr = reinterpret_cast<scalar_t*>(std::realloc(ptr, new_size * sizeof(scalar_t)));
 
     if (new_ptr == nullptr) {
-        throw std::bad_alloc();
+        return nullptr;
     }
 
+#ifndef NDEBUG
     // initialize with a bit pattern that maps to NaN for double
     std::memset(new_ptr + size, 0b11111111, (new_size - size) * sizeof(scalar_t));
+#endif
 
     return new_ptr;
 }
@@ -356,6 +359,19 @@ void GrowableNeighborList::grow() {
         new_vectors = alloc<double, 3>(neighbors.vectors, neighbors.length, new_size);
     }
 
+    if (
+        (new_pairs == nullptr) ||
+        (options.return_shifts && new_shifts == nullptr) ||
+        (options.return_distances && new_distances == nullptr) ||
+        (options.return_vectors && new_vectors == nullptr)
+    ) {
+        std::free(new_pairs);
+        std::free(new_shifts);
+        std::free(new_distances);
+        std::free(new_vectors);
+        throw std::runtime_error("could not allocate memory for growing neighbor list");
+    }
+
     this->neighbors.pairs = new_pairs;
     this->neighbors.shifts = new_shifts;
     this->neighbors.distances = new_distances;
@@ -365,21 +381,23 @@ void GrowableNeighborList::grow() {
 }
 
 void GrowableNeighborList::reset() {
-    // set all allocated data to zero
+#ifndef NDEBUG
     auto size = this->neighbors.length;
-    std::memset(this->neighbors.pairs, 0, size * sizeof(size_t[2]));
+    // set all allocated data to a bit pattern that maps to NaN for double
+    std::memset(this->neighbors.pairs, 0b11111111, size * sizeof(size_t[2]));
 
     if (this->neighbors.shifts != nullptr) {
-        std::memset(this->neighbors.shifts, 0, size * sizeof(int32_t[3]));
+        std::memset(this->neighbors.shifts, 0b11111111, size * sizeof(int32_t[3]));
     }
 
     if (this->neighbors.distances != nullptr) {
-        std::memset(this->neighbors.distances, 0, size * sizeof(double));
+        std::memset(this->neighbors.distances, 0b11111111, size * sizeof(double));
     }
 
     if (this->neighbors.vectors != nullptr) {
-        std::memset(this->neighbors.vectors, 0, size * sizeof(double[3]));
+        std::memset(this->neighbors.vectors, 0b11111111, size * sizeof(double[3]));
     }
+#endif
 
     // reset length (but keep the capacity where it's at)
     this->neighbors.length = 0;

--- a/vesin/src/cpu_cell_list.cpp
+++ b/vesin/src/cpu_cell_list.cpp
@@ -442,41 +442,20 @@ void GrowableNeighborList::sort() {
     std::iota(std::begin(indices), std::end(indices), 0);
 
     struct compare_pairs {
-        compare_pairs(size_t (*pairs_)[2], int32_t (*shifts_)[3], bool with_shifts_):
-            pairs(pairs_),
-            shifts(shifts_),
-            with_shifts(with_shifts_) {}
+        compare_pairs(size_t (*pairs_)[2]):
+            pairs(pairs_) {}
 
         bool operator()(int64_t a, int64_t b) const {
-            if (pairs[a][0] == pairs[b][0]) {
-                if (pairs[a][1] == pairs[b][1]) {
-                    if (!with_shifts) {
-                        return false;
-                    }
-
-                    if (shifts[a][0] == shifts[b][0]) {
-                        if (shifts[a][1] == shifts[b][1]) {
-                            return shifts[a][2] < shifts[b][2];
-                        }
-                        return shifts[a][1] < shifts[b][1];
-                    }
-                    return shifts[a][0] < shifts[b][0];
-                }
-                return pairs[a][1] < pairs[b][1];
-            } else {
-                return pairs[a][0] < pairs[b][0];
-            }
+            return pairs[a][0] < pairs[b][0];
         }
 
         size_t (*pairs)[2];
-        int32_t (*shifts)[3];
-        bool with_shifts;
     };
 
     std::sort(
         std::begin(indices),
         std::end(indices),
-        compare_pairs(this->neighbors.pairs, this->neighbors.shifts, options.return_shifts)
+        compare_pairs(this->neighbors.pairs)
     );
 
     // step 2: move all data according to the sorted indices.

--- a/vesin/src/cuda_sort_pairs.cu
+++ b/vesin/src/cuda_sort_pairs.cu
@@ -1,54 +1,12 @@
 __device__ inline bool pair_less(
     const size_t* pairs,
-    const int* shifts,
     size_t a,
-    size_t b,
-    bool with_shifts
+    size_t b
 ) {
     size_t ai = pairs[a * 2 + 0];
-    size_t aj = pairs[a * 2 + 1];
     size_t bi = pairs[b * 2 + 0];
-    size_t bj = pairs[b * 2 + 1];
 
-    if (ai < bi) {
-        return true;
-    }
-    if (ai > bi) {
-        return false;
-    }
-    if (aj < bj) {
-        return true;
-    }
-    if (aj > bj) {
-        return false;
-    }
-
-    if (!with_shifts) {
-        return false;
-    }
-
-    int asx = shifts[a * 3 + 0];
-    int asy = shifts[a * 3 + 1];
-    int asz = shifts[a * 3 + 2];
-    int bsx = shifts[b * 3 + 0];
-    int bsy = shifts[b * 3 + 1];
-    int bsz = shifts[b * 3 + 2];
-
-    if (asx < bsx) {
-        return true;
-    }
-    if (asx > bsx) {
-        return false;
-    }
-
-    if (asy < bsy) {
-        return true;
-    }
-    if (asy > bsy) {
-        return false;
-    }
-
-    return asz < bsz;
+    return ai < bi;
 }
 
 __device__ inline void swap_pair_payload(
@@ -184,7 +142,7 @@ __global__ void sort_pairs_bitonic_step(
     }
 
     bool ascending = ((idx & k) == 0);
-    bool idx_less = pair_less(pairs, shifts, idx, ixj, return_shifts);
+    bool idx_less = pair_less(pairs, idx, ixj);
     bool should_swap = ascending ? !idx_less : idx_less;
 
     if (should_swap) {


### PR DESCRIPTION
On CPU, this now allocated temporary buffers instead of trying to sort in place. Additionally, the pair list is only sorted by `i` and not `j`, which is enough for most 95% of use cases.

Benchmarks for 6A cutoff:

- `main`: 7.3ms for 500 atoms, 1600ms for 50k atoms
- temporary buffers: 7.1ms for 500 atoms, 779ms for 50k atoms
- only sorting by `i` instead of `ijS`: 5.1ms for 500 atoms, 520ms for 50k atoms
