### PR TITLE
Add a version of the single file build without cuda

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -313,14 +313,14 @@ jobs:
 
       - name: create single file build
         run: |
-          python create-single-cpp.py
+          python ./vesin/scripts/create-single-cpp.py
 
       - name: upload to GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            vesin-single-build-v*.tar.gz
+            ./vesin/dist/vesin-single-build-v*.tar.gz
           prerelease: ${{ contains(github.ref, '-rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ dist/
 __pycache__/
 
 *.egg-info
-
-vesin-single-build.cpp
-vesin-single-build-v*.tar.gz

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -173,11 +173,12 @@ Installation
 
             git clone https://github.com/Luthaf/vesin.git
             cd vesin
-            python create-single-cpp.py
+            python ./vesin/scripts/create-single-cpp.py
 
         Then you'll need to copy both ``include/vesin.h`` and
         ``vesin-single-build.cpp`` in your project and configure your build
-        system accordingly.
+        system accordingly. If you don't need CUDA support, you can use
+        ``vesin-single-build-nocuda.cpp`` instead of ``vesin-single-build.cpp``.
 
         You should define ``VESIN_SHARED`` as a preprocessor constant
         (``-DVESIN_SHARED``) when compiling the code if you want to build vesin

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     torchscript-tests
     cxx-tests
     fortran-tests
+    single-build-tests
 
 [testenv]
 lint-folders = python setup.py
@@ -129,6 +130,18 @@ commands =
     cmake -B {envtmpdir} -S vesin -DVESIN_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
     cmake --build {envtmpdir} --config Debug
     ctest --test-dir {envtmpdir} --build-config Debug --output-on-failure
+
+
+[testenv:single-build-tests]
+passenv = *
+description = Check that the single file can be created and compiled
+package = skip
+deps = cmake
+
+commands =
+    python ./vesin/scripts/create-single-cpp.py
+    cmake -B {envtmpdir} -S vesin/tests/single-cpp -DSINGLE_BUILD_DIR={toxinidir}/vesin/dist/
+    cmake --build {envtmpdir} --config Debug
 
 
 [testenv:fortran-tests]

--- a/vesin/scripts/create-single-cpp.py
+++ b/vesin/scripts/create-single-cpp.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python
 import os
+import shutil
 import subprocess
 import tarfile
 import tempfile
 
 
 HERE = os.path.dirname(os.path.realpath(__file__))
+ROOT = os.path.realpath(os.path.join(HERE, "..", ".."))
+DIST = os.path.realpath(os.path.join(HERE, "..", "dist"))
 ALREADY_SEEN = set()
 
 
 def find_file(path):
     candidates = [
-        os.path.join(HERE, "vesin", "src", path),
-        os.path.join(HERE, "vesin", "include", path),
+        os.path.join(ROOT, "vesin", "src", path),
+        os.path.join(ROOT, "vesin", "include", path),
         os.path.join(os.getcwd(), path),
         os.path.join(os.getcwd(), "_deps", "gpulite-src", path),
     ]
@@ -64,7 +67,7 @@ def merge_files(path, output):
 
 
 def add_version(output):
-    with open(os.path.join(HERE, "vesin", "VERSION")) as fd:
+    with open(os.path.join(ROOT, "vesin", "VERSION")) as fd:
         version = fd.read().strip()
 
     output.write("// automatically generated \n")
@@ -72,13 +75,13 @@ def add_version(output):
 
 
 if __name__ == "__main__":
-    with open(os.path.join(HERE, "vesin", "VERSION")) as fd:
+    with open(os.path.join(ROOT, "vesin", "VERSION")) as fd:
         version = fd.read().strip()
 
     with tempfile.TemporaryDirectory() as tempdir:
         os.chdir(tempdir)
         subprocess.run(
-            ["cmake", os.path.join(HERE, "vesin")],
+            ["cmake", os.path.join(ROOT, "vesin")],
             check=True,
         )
 
@@ -87,23 +90,40 @@ if __name__ == "__main__":
             check=True,
         )
 
-        with open(os.path.join(HERE, "vesin-single-build.cpp"), "w") as output:
+        os.makedirs(DIST, exist_ok=True)
+
+        ALREADY_SEEN.clear()
+        with open(os.path.join(DIST, "vesin-single-build.cpp"), "w") as output:
             add_version(output)
             merge_files("cpu_cell_list.cpp", output)
             merge_files("vesin_cuda.cpp", output)
             merge_files("vesin.cpp", output)
 
-        tarpath = os.path.join(HERE, f"vesin-single-build-v{version}.tar.gz")
+        ALREADY_SEEN.clear()
+        with open(os.path.join(DIST, "vesin-single-build-nocuda.cpp"), "w") as output:
+            add_version(output)
+            merge_files("cpu_cell_list.cpp", output)
+            merge_files("vesin_cuda_stub.cpp", output)
+            merge_files("vesin.cpp", output)
+
+        shutil.copyfile(
+            os.path.join(ROOT, "vesin", "include", "vesin.h"),
+            os.path.join(DIST, "vesin.h"),
+        )
+
+        tarpath = os.path.join(DIST, f"vesin-single-build-v{version}.tar.gz")
         with tarfile.open(tarpath, "w:gz") as tar:
             tar.add(
-                os.path.join(HERE, "vesin-single-build.cpp"),
+                os.path.join(DIST, "vesin-single-build.cpp"),
                 arcname="vesin-single-build.cpp",
             )
             tar.add(
-                os.path.join(HERE, "vesin", "include", "vesin.h"),
+                os.path.join(DIST, "vesin-single-build-nocuda.cpp"),
+                arcname="vesin-single-build-nocuda.cpp",
+            )
+            tar.add(
+                os.path.join(DIST, "vesin.h"),
                 arcname="vesin.h",
             )
 
-    print(
-        f"created 'vesin-single-build.cpp' and 'vesin-single-build-v{version}.tar.gz'"
-    )
+    print(f"created single build files in {DIST}/")

--- a/vesin/src/vesin_cuda_stub.cpp
+++ b/vesin/src/vesin_cuda_stub.cpp
@@ -1,0 +1,18 @@
+#include <stdexcept>
+
+#include "vesin_cuda.hpp"
+
+void vesin::cuda::free_neighbors(VesinNeighborList& neighbors) {
+    throw std::runtime_error("CUDA neighbor list generation is not included in this build of vesin");
+}
+
+void vesin::cuda::neighbors(
+    const double (*points)[3],
+    size_t n_points,
+    const double box[3][3],
+    const bool periodic[3],
+    VesinOptions options,
+    VesinNeighborList& neighbors
+) {
+    throw std::runtime_error("CUDA neighbor list generation is not included in this build of vesin");
+}

--- a/vesin/tests/single-cpp/CMakeLists.txt
+++ b/vesin/tests/single-cpp/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(test_vesin_single_build LANGUAGES C CXX)
+
+add_library(vesin-single-build ${SINGLE_BUILD_DIR}/vesin-single-build.cpp)
+add_library(vesin-single-build-nocuda ${SINGLE_BUILD_DIR}/vesin-single-build-nocuda.cpp)
+
+target_include_directories(vesin-single-build PUBLIC ${SINGLE_BUILD_DIR})
+target_include_directories(vesin-single-build-nocuda PUBLIC ${SINGLE_BUILD_DIR})
+
+target_compile_features(vesin-single-build PUBLIC cxx_std_17)
+target_compile_features(vesin-single-build-nocuda PUBLIC cxx_std_17)
+
+add_executable(main main.cpp)
+add_executable(main-nocuda main.cpp)
+
+target_link_libraries(main vesin-single-build)
+target_link_libraries(main-nocuda vesin-single-build-nocuda)

--- a/vesin/tests/single-cpp/main.cpp
+++ b/vesin/tests/single-cpp/main.cpp
@@ -1,0 +1,15 @@
+#include <vesin.h>
+
+int main() {
+    auto neighbors = VesinNeighborList();
+
+    auto options = VesinOptions();
+    options.cutoff = 5.0;
+    options.full = true;
+    options.return_shifts = true;
+
+    const char* error_message = nullptr;
+    vesin_neighbors(nullptr, 0, nullptr, nullptr, VesinDevice{VesinCPU, 0}, options, &neighbors, &error_message);
+
+    vesin_free(&neighbors);
+}


### PR DESCRIPTION
The cuda code adds 8k lines which are not needed in most cases where someone would use the single file build