### PR TITLE
Add more tests against ASE

### DIFF
--- a/python/vesin/tests/_utils.py
+++ b/python/vesin/tests/_utils.py
@@ -1,0 +1,222 @@
+import os
+from dataclasses import dataclass
+
+import ase.io
+import numpy as np
+
+
+CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def _min_periodic_box_dimension(system) -> float | None:
+    periodic_lengths = [
+        float(np.linalg.norm(system.box[index]))
+        for index, is_periodic in enumerate(system.periodic)
+        if is_periodic
+    ]
+    if len(periodic_lengths) == 0:
+        return None
+    return min(periodic_lengths)
+
+
+def algorithm_is_applicable(
+    system,
+    cutoff: float,
+    gpu_algorithm: str,
+) -> bool:
+    if gpu_algorithm == "cell_list":
+        return True
+
+    min_periodic_dim = _min_periodic_box_dimension(system)
+    if min_periodic_dim is None:
+        return True
+
+    return cutoff <= min_periodic_dim / 2.0
+
+
+def _random_transform_matrix() -> tuple[np.ndarray, bool]:
+    rng = np.random.default_rng()
+    rotation, _ = np.linalg.qr(rng.normal(size=(3, 3)))
+
+    if np.linalg.det(rotation) < 0:
+        rotation[:, 0] *= -1
+
+    inverted = bool(rng.integers(2))
+    if inverted:
+        rotation = -rotation
+
+    return rotation
+
+
+def _random_translation() -> np.ndarray:
+    rng = np.random.default_rng()
+    return rng.uniform(-100.0, 100.0, size=3)
+
+
+def _format_transformation(
+    *,
+    transform: np.ndarray | None,
+    translation: np.ndarray | None,
+) -> str:
+    if transform is None and translation is None:
+        return ""
+
+    transform_text = np.array2string(
+        transform,
+        precision=17,
+        suppress_small=False,
+    )
+    message = f"random transform matrix:\n{transform_text}"
+
+    if translation is None:
+        return message
+
+    translation_text = np.array2string(
+        translation,
+        precision=17,
+        suppress_small=False,
+    )
+    return f"{message}\nrandom translation vector:\n{translation_text}"
+
+
+@dataclass(frozen=True)
+class SystemForTests:
+    name: str
+    transform_summary: str
+    points: np.ndarray
+    box: np.ndarray
+    periodic: tuple[bool, bool, bool]
+
+    def __str__(self) -> str:
+        return self.name
+
+    def transform(self, translate: bool = False) -> "SystemForTests":
+        transform = _random_transform_matrix()
+        translation = _random_translation() if translate else None
+        points = self.points @ transform.T
+        if translation is not None:
+            points = points + translation
+
+        transform_summary = _format_transformation(
+            transform=transform,
+            translation=translation,
+        )
+
+        return SystemForTests(
+            name=self.name,
+            transform_summary=transform_summary,
+            points=points,
+            box=self.box @ transform.T,
+            periodic=self.periodic,
+        )
+
+
+def polymer_chain() -> SystemForTests:
+    # Carbon backbone with realistic C-C distances for a simple 1D polymer-like chain.
+    spacing = 1.54
+    points = np.array(
+        [[index * spacing, 0.0, 0.0] for index in range(8)], dtype=np.float64
+    )
+    box = np.diag([8 * spacing, 18.0, 18.0]).astype(np.float64)
+    return SystemForTests(
+        name="polymer_chain",
+        transform_summary="",
+        points=points,
+        box=box,
+        periodic=(True, False, False),
+    )
+
+
+def graphene_sheet() -> SystemForTests:
+    # 4x4 graphene supercell in the xy plane with vacuum along z.
+    a1 = np.array([2.46, 0.0, 0.0])
+    a2 = np.array([1.23, 2.13042249, 0.0])
+    basis = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([1.23, 0.71014083, 0.0]),
+    ]
+
+    points = []
+    for i in range(4):
+        for j in range(4):
+            origin = i * a1 + j * a2
+            for atom in basis:
+                points.append(origin + atom)
+
+    return SystemForTests(
+        name="graphene_sheet_2d",
+        transform_summary="",
+        points=np.asarray(points, dtype=np.float64),
+        box=np.array(
+            [
+                [9.84, 0.0, 0.0],
+                [4.92, 8.52168996, 0.0],
+                [0.0, 0.0, 18.0],
+            ],
+            dtype=np.float64,
+        ),
+        periodic=(True, True, False),
+    )
+
+
+def diamond_crystal() -> SystemForTests:
+    atoms = ase.io.read(f"{CURRENT_DIR}/data/diamond.xyz")
+    atoms = atoms.repeat((2, 2, 2))
+    rng = np.random.default_rng(1234)
+    positions = np.asarray(atoms.positions, dtype=np.float64).copy()
+    positions += rng.normal(scale=1.0, size=positions.shape)
+    return SystemForTests(
+        name="diamond_crystal_3d",
+        transform_summary="",
+        points=positions,
+        box=np.asarray(atoms.cell[:], dtype=np.float64),
+        periodic=tuple(bool(value) for value in atoms.pbc),
+    )
+
+
+def naphthalene_cluster() -> SystemForTests:
+    atoms = ase.io.read(f"{CURRENT_DIR}/data/naphthalene.xyz")
+    return SystemForTests(
+        name="naphthalene_cluster_non_periodic",
+        transform_summary="",
+        points=np.asarray(atoms.positions, dtype=np.float64),
+        box=np.diag([30.0, 30.0, 30.0]).astype(np.float64),
+        periodic=(False, False, False),
+    )
+
+
+def issue_153() -> SystemForTests:
+    return SystemForTests(
+        name="issue_153",
+        transform_summary="",
+        points=np.asarray([[0.0, 2.5, 0.0], [2.0, 0.0, 0.0]], dtype=np.float64),
+        box=np.diag([4.0, 4.5, 0.0]).astype(np.float64),
+        periodic=(True, True, False),
+    )
+
+
+def system_from_xyz(name):
+    atoms = ase.io.read(f"{CURRENT_DIR}/data/{name}.xyz")
+    return SystemForTests(
+        name=name,
+        transform_summary="",
+        points=atoms.positions,
+        box=atoms.cell[:],
+        periodic=atoms.pbc,
+    )
+
+
+TEST_SYSTEMS = [
+    system_from_xyz("water"),
+    system_from_xyz("diamond"),
+    system_from_xyz("naphthalene"),
+    system_from_xyz("carbon"),
+    system_from_xyz("slab"),
+    system_from_xyz("Cd2I4O12"),
+    system_from_xyz("rotated_box"),
+    naphthalene_cluster(),
+    polymer_chain(),
+    graphene_sheet(),
+    diamond_crystal(),
+    issue_153(),
+]

--- a/python/vesin/tests/test_gpu_consistency.py
+++ b/python/vesin/tests/test_gpu_consistency.py
@@ -1,10 +1,7 @@
-import os
-from dataclasses import dataclass
-
-import ase.io
 import numpy as np
 import pytest
 
+from _utils import TEST_SYSTEMS, algorithm_is_applicable
 from vesin import NeighborList
 
 
@@ -14,17 +11,6 @@ try:
     cp.cuda.Device(0).compute_capability
 except cp.cuda.runtime.CUDARuntimeError:
     pytest.skip("CUDA is not available", allow_module_level=True)
-
-
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-
-@dataclass(frozen=True)
-class SystemForTests:
-    name: str
-    points: np.ndarray
-    box: np.ndarray
-    periodic: tuple[bool, bool, bool]
 
 
 def sort_neighbors(i, j, S, D, d):
@@ -54,17 +40,29 @@ def compute_neighbors(points, box, periodic, cutoff, full_list, algorithm, sorte
     )
 
 
-def compare_cpu_gpu(
-    case: SystemForTests,
-    cutoff: float,
-    full_list: bool,
-    gpu_algorithm: str,
-    sorted: bool,
-):
+@pytest.mark.parametrize("full_list", [False, True])
+@pytest.mark.parametrize("system", TEST_SYSTEMS, ids=[s.name for s in TEST_SYSTEMS])
+@pytest.mark.parametrize("cutoff", [3.0, 5.0, 7.0, 10.0])
+@pytest.mark.parametrize("gpu_algorithm", ["cell_list", "brute_force"])
+@pytest.mark.parametrize("sorted", [False, True])
+@pytest.mark.parametrize("transform", ["none", "rotate", "rotate_and_translate"])
+def test_gpu_matches_cpu(system, cutoff, full_list, gpu_algorithm, sorted, transform):
+    if not algorithm_is_applicable(system, cutoff, gpu_algorithm):
+        return
+
+    if transform == "none":
+        pass
+    elif transform == "rotate":
+        system = system.transform(translate=False)
+    elif transform == "rotate_and_translate":
+        system = system.transform(translate=True)
+    else:
+        raise ValueError(f"Unknown transform: {transform}")
+
     cpu_i, cpu_j, cpu_S, cpu_D, cpu_d = compute_neighbors(
-        points=case.points,
-        box=case.box,
-        periodic=case.periodic,
+        points=system.points,
+        box=system.box,
+        periodic=system.periodic,
         cutoff=cutoff,
         full_list=full_list,
         algorithm="cell_list",
@@ -79,9 +77,9 @@ def compare_cpu_gpu(
     )
 
     gpu_i, gpu_j, gpu_S, gpu_D, gpu_d = compute_neighbors(
-        points=cp.asarray(case.points, dtype=cp.float64),
-        box=cp.asarray(case.box, dtype=cp.float64),
-        periodic=cp.asarray(case.periodic),
+        points=cp.asarray(system.points, dtype=cp.float64),
+        box=cp.asarray(system.box, dtype=cp.float64),
+        periodic=cp.asarray(system.periodic),
         cutoff=cutoff,
         full_list=full_list,
         algorithm=gpu_algorithm,
@@ -96,152 +94,13 @@ def compare_cpu_gpu(
         cp.asnumpy(gpu_d),
     )
 
-    assert np.array_equal(cpu_i, gpu_i)
-    assert np.array_equal(cpu_j, gpu_j)
-    assert np.array_equal(cpu_S, gpu_S)
-    assert np.allclose(cpu_D, gpu_D)
-    assert np.allclose(cpu_d, gpu_d)
-
-
-def polymer_chain() -> SystemForTests:
-    # Carbon backbone with realistic C-C distances for a simple 1D polymer-like chain.
-    spacing = 1.54
-    points = np.array(
-        [[index * spacing, 0.0, 0.0] for index in range(8)], dtype=np.float64
-    )
-    box = np.diag([8 * spacing, 18.0, 18.0]).astype(np.float64)
-    return SystemForTests(
-        name="polymer_chain_1d",
-        points=points,
-        box=box,
-        periodic=(True, False, False),
+    message = (
+        f"Neighbors do not match between CPU and GPU for {system.name}, "
+        f"transformed with {system.transform_summary}."
     )
 
-
-def graphene_sheet() -> SystemForTests:
-    # 4x4 graphene supercell in the xy plane with vacuum along z.
-    a1 = np.array([2.46, 0.0, 0.0])
-    a2 = np.array([1.23, 2.13042249, 0.0])
-    basis = [
-        np.array([0.0, 0.0, 0.0]),
-        np.array([1.23, 0.71014083, 0.0]),
-    ]
-
-    points = []
-    for i in range(4):
-        for j in range(4):
-            origin = i * a1 + j * a2
-            for atom in basis:
-                points.append(origin + atom)
-
-    return SystemForTests(
-        name="graphene_sheet_2d",
-        points=np.asarray(points, dtype=np.float64),
-        box=np.array(
-            [
-                [9.84, 0.0, 0.0],
-                [4.92, 8.52168996, 0.0],
-                [0.0, 0.0, 18.0],
-            ],
-            dtype=np.float64,
-        ),
-        periodic=(True, True, False),
-    )
-
-
-def diamond_crystal() -> SystemForTests:
-    atoms = ase.io.read(f"{CURRENT_DIR}/data/diamond.xyz")
-    atoms = atoms.repeat((2, 2, 2))
-    rng = np.random.default_rng(1234)
-    positions = np.asarray(atoms.positions, dtype=np.float64).copy()
-    positions += rng.normal(scale=1.0, size=positions.shape)
-    return SystemForTests(
-        name="diamond_crystal_3d",
-        points=positions,
-        box=np.asarray(atoms.cell[:], dtype=np.float64),
-        periodic=tuple(bool(value) for value in atoms.pbc),
-    )
-
-
-def naphthalene_cluster() -> SystemForTests:
-    atoms = ase.io.read(f"{CURRENT_DIR}/data/naphthalene.xyz")
-    return SystemForTests(
-        name="naphthalene_cluster_0d",
-        points=np.asarray(atoms.positions, dtype=np.float64),
-        box=np.diag([30.0, 30.0, 30.0]).astype(np.float64),
-        periodic=(False, False, False),
-    )
-
-
-def issue_153() -> SystemForTests:
-    return SystemForTests(
-        name="issue_153",
-        points=np.asarray([[0.0, 2.5, 0.0], [2.0, 0.0, 0.0]], dtype=np.float64),
-        box=np.diag([4.0, 4.5, 0.0]).astype(np.float64),
-        periodic=(True, True, False),
-    )
-
-
-def issue_157() -> SystemForTests:
-    atoms = ase.io.read(f"{CURRENT_DIR}/data/rotated_box.xyz")
-    return SystemForTests(
-        name="rotated_box",
-        points=atoms.positions,
-        box=np.asarray(atoms.cell[:], dtype=np.float64),
-        periodic=atoms.pbc,
-    )
-
-
-SYSTEMS_FOR_TESTS = [
-    naphthalene_cluster(),
-    polymer_chain(),
-    graphene_sheet(),
-    diamond_crystal(),
-    issue_153(),
-    issue_157(),
-]
-
-CUTOFFS = [3.0, 5.0, 7.0, 10.0]
-
-
-def min_periodic_box_dimension(case: SystemForTests) -> float | None:
-    periodic_lengths = [
-        float(np.linalg.norm(case.box[index]))
-        for index, is_periodic in enumerate(case.periodic)
-        if is_periodic
-    ]
-    if len(periodic_lengths) == 0:
-        return None
-    return min(periodic_lengths)
-
-
-def gpu_algorithm_is_applicable(
-    case: SystemForTests,
-    cutoff: float,
-    gpu_algorithm: str,
-) -> bool:
-    if gpu_algorithm == "cell_list":
-        return True
-
-    min_periodic_dim = min_periodic_box_dimension(case)
-    if min_periodic_dim is None:
-        return True
-
-    return cutoff <= min_periodic_dim / 2.0
-
-
-@pytest.mark.parametrize("full_list", [False, True])
-@pytest.mark.parametrize(
-    "system", SYSTEMS_FOR_TESTS, ids=[case.name for case in SYSTEMS_FOR_TESTS]
-)
-@pytest.mark.parametrize("cutoff", CUTOFFS)
-@pytest.mark.parametrize("gpu_algorithm", ["cell_list", "brute_force"])
-@pytest.mark.parametrize("sorted", [False, True])
-def test_gpu_matches_cpu_for_fixed_systems(
-    system, cutoff, full_list, gpu_algorithm, sorted, monkeypatch
-):
-    if not gpu_algorithm_is_applicable(system, cutoff, gpu_algorithm):
-        return
-
-    # monkeypatch.setenv("VESIN_CUDA_MAX_PAIRS_PER_POINT", "4096")
-    compare_cpu_gpu(system, cutoff, full_list, gpu_algorithm, sorted)
+    assert np.array_equal(cpu_i, gpu_i), message
+    assert np.array_equal(cpu_j, gpu_j), message
+    assert np.array_equal(cpu_S, gpu_S), message
+    assert np.allclose(cpu_D, gpu_D), message
+    assert np.allclose(cpu_d, gpu_d), message

--- a/python/vesin/tests/test_numpy.py
+++ b/python/vesin/tests/test_numpy.py
@@ -8,54 +8,83 @@ import numpy as np
 import pytest
 
 import vesin
+from _utils import TEST_SYSTEMS
 from vesin import NeighborList
 
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def non_sorted_nl(quantities, atoms, cutoff):
-    calculator = NeighborList(cutoff=cutoff, full_list=True, sorted=False)
-    outputs = calculator.compute(
-        points=atoms.positions,
-        box=atoms.cell[:],
-        periodic=atoms.pbc,
-        quantities=quantities,
-        copy=False,
-    )
-    # since we have `copy=False`, also return the calculator to keep the memory alive
-    return *outputs, calculator
-
-
-@pytest.mark.parametrize(
-    "system",
-    ["water", "diamond", "naphthalene", "carbon", "slab", "Cd2I4O12", "rotated_box"],
-)
-@pytest.mark.parametrize("cutoff", [float(i) for i in range(1, 10)])
-@pytest.mark.parametrize("vesin_nl", [vesin.ase_neighbor_list, non_sorted_nl])
-def test_neighbors(system, cutoff, vesin_nl):
-    atoms = ase.io.read(f"{CURRENT_DIR}/data/{system}.xyz")
-
-    ase_i, ase_j, ase_S, ase_D = ase.neighborlist.neighbor_list("ijSD", atoms, cutoff)
-    vesin_i, vesin_j, vesin_S, vesin_D, *_ = vesin_nl("ijSD", atoms, cutoff)
-
-    assert len(ase_i) == len(vesin_i)
-    assert len(ase_j) == len(vesin_j)
-    assert len(ase_S) == len(vesin_S)
-    assert len(ase_D) == len(vesin_D)
-
-    ase_ijS = np.concatenate(
-        (ase_i.reshape(-1, 1), ase_j.reshape(-1, 1), ase_S), axis=1
-    )
-    vesin_ijS = np.concatenate(
-        (vesin_i.reshape(-1, 1), vesin_j.reshape(-1, 1), vesin_S), axis=1
+def sort_neighbors(i, j, S, D, d):
+    ijS = np.concatenate((i.reshape(-1, 1), j.reshape(-1, 1), S), axis=1)
+    sort_indices = np.lexsort(np.flip(ijS, axis=1).T)
+    return (
+        i[sort_indices],
+        j[sort_indices],
+        S[sort_indices],
+        D[sort_indices],
+        d[sort_indices],
     )
 
-    ase_sort_indices = np.lexsort(ase_ijS.T)
-    vesin_sort_indices = np.lexsort(vesin_ijS.T)
 
-    assert np.array_equal(ase_ijS[ase_sort_indices], vesin_ijS[vesin_sort_indices])
-    assert np.allclose(ase_D[ase_sort_indices], vesin_D[vesin_sort_indices])
+def ase_neighbors(system, cutoff):
+    atoms = ase.Atoms(
+        positions=system.points,
+        cell=system.box,
+        pbc=system.periodic,
+    )
+    return sort_neighbors(*ase.neighborlist.neighbor_list("ijSDd", atoms, cutoff))
+
+
+def vesin_neighbors(system, cutoff, sorted):
+    calculator = NeighborList(
+        cutoff=cutoff,
+        full_list=True,
+        sorted=sorted,
+        algorithm="cell_list",
+    )
+
+    neighbors = calculator.compute(
+        points=system.points,
+        box=system.box,
+        periodic=system.periodic,
+        quantities="ijSDd",
+    )
+
+    return sort_neighbors(*neighbors)
+
+
+@pytest.mark.parametrize("system", TEST_SYSTEMS, ids=[s.name for s in TEST_SYSTEMS])
+@pytest.mark.parametrize("cutoff", [3.0, 5.0, 7.0, 10.0])
+@pytest.mark.parametrize("sorted", [True, False])
+@pytest.mark.parametrize("transform", ["none", "rotate", "rotate_and_translate"])
+def test_against_ase(system, cutoff, sorted, transform):
+    if transform == "none":
+        pass
+    elif transform == "rotate":
+        system = system.transform(translate=False)
+    elif transform == "rotate_and_translate":
+        system = system.transform(translate=True)
+    else:
+        raise ValueError(f"Unknown transform: {transform}")
+
+    expected_i, expected_j, expected_S, expected_D, expected_d = ase_neighbors(
+        system, cutoff
+    )
+    actual_i, actual_j, actual_S, actual_D, actual_d = vesin_neighbors(
+        system, cutoff, sorted=sorted
+    )
+
+    message = (
+        f"Neighbors do not match between ASE and vesin for {system.name}, "
+        f"transformed with {system.transform_summary}."
+    )
+
+    assert np.array_equal(actual_i, expected_i), message
+    assert np.array_equal(actual_j, expected_j), message
+    assert np.array_equal(actual_S, expected_S), message
+    assert np.allclose(actual_D, expected_D), message
+    assert np.allclose(actual_d, expected_d), message
 
 
 def test_slab_slow():

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,7 +4,7 @@ ignore = ["B018", "B904"]
 
 [lint.isort]
 lines-after-imports = 2
-known-first-party = ["vesin"]
+known-first-party = ["vesin", "_utils"]
 known-third-party = ["torch"]
 
 [format]

--- a/vesin/src/cpu_cell_list.cpp
+++ b/vesin/src/cpu_cell_list.cpp
@@ -237,6 +237,31 @@ CellList::CellList(BoundingBox box, double cutoff):
         }
     }
 
+    // When there is mixed periodicity (some dimensions periodic, some not),
+    // periodic shifts can bring atoms together across multiple cells in
+    // non-periodic dimensions. Increase the search range in non-periodic
+    // dimensions to cover the full cell extent in those dimensions.
+    bool has_periodic = false;
+    bool has_non_periodic = false;
+    for (size_t d = 0; d < 3; d++) {
+        if (box_.periodic(d)) {
+            has_periodic = true;
+        } else {
+            has_non_periodic = true;
+        }
+    }
+
+    if (has_periodic && has_non_periodic) {
+        for (size_t spatial = 0; spatial < 3; spatial++) {
+            if (!box_.periodic(spatial)) {
+                n_search_[spatial] = std::max(
+                    n_search_[spatial],
+                    static_cast<int32_t>(cells_shape_[spatial]) - 1
+                );
+            }
+        }
+    }
+
     this->cells_.resize(cells_shape_[0] * cells_shape_[1] * cells_shape_[2]);
 }
 
@@ -274,15 +299,32 @@ void CellList::foreach_pair(Function callback) {
         for (int32_t delta_x=-n_search_[0]; delta_x<=n_search_[0]; delta_x++) {
         for (int32_t delta_y=-n_search_[1]; delta_y<=n_search_[1]; delta_y++) {
         for (int32_t delta_z=-n_search_[2]; delta_z<=n_search_[2]; delta_z++) {
-            auto cell_i = std::array<int32_t, 3>{
+            // shift vector from one cell to the other
+            auto cell_shift = std::array<int32_t, 3>{0, 0, 0};
+            // index of the neighboring cell
+            auto neighbor_cell_i = std::array<int32_t, 3>{
                 cell_i_x + delta_x,
                 cell_i_y + delta_y,
                 cell_i_z + delta_z,
             };
 
-            // shift vector from one cell to the other and index of
-            // the neighboring cell
-            auto [cell_shift, neighbor_cell_i] = divmod(cell_i, cells_shape_);
+            // only wrap (i.e. call divmod) cell indices in periodic dimensions,
+            // skip out-of-bounds cells in non-periodic ones
+            bool cell_is_valid = true;
+            for (int d = 0; d < 3; d++) {
+                if (box_.periodic(d)) {
+                    auto [q, r] = divmod(neighbor_cell_i[d], cells_shape_[d]);
+                    cell_shift[d] = q;
+                    neighbor_cell_i[d] = r;
+                } else if (neighbor_cell_i[d] < 0 || neighbor_cell_i[d] >= static_cast<int32_t>(cells_shape_[d])) {
+                    cell_is_valid = false;
+                    break;
+                }
+            }
+
+            if (!cell_is_valid) {
+                continue;
+            }
 
             for (const auto& atom_i: current_cell) {
                 for (const auto& atom_j: this->get_cell(neighbor_cell_i)) {

--- a/vesin/src/cuda_cell_list.cu
+++ b/vesin/src/cuda_cell_list.cu
@@ -254,6 +254,17 @@ __global__ void compute_cell_grid_params(
         double cell_size = face_distances[dim] / n_cells[dim];
         n_search[dim] = max(1, (int)ceil(cutoff / cell_size));
     }
+
+    // When there is mixed periodicity, increase search in non-periodic
+    // dimensions to account for periodic shifts that can bring atoms
+    // together across the bounding box.
+    if (n_periodic > 0 && n_periodic < 3) {
+        for (int dim = 0; dim < 3; dim++) {
+            if (!periodic[dim]) {
+                n_search[dim] = max(n_search[dim], n_cells[dim] - 1);
+            }
+        }
+    }
 }
 
 // Map particles to cells via fractional coords, record periodic wrap shifts


### PR DESCRIPTION
This PR adds tests on CPU and CUDA, testing all backends and including the latest tricky systems, against ASE. A random rotation/inversion is also tested for each system, and these transformations are not fixed, but randomly generated each time. In case of a failure, the transformation matrix is printed for reproducibility. This should guarantee that we will catch augmentation-related bugs (in the long run)

Potentially replaces #162 and #163