### PR TITLE
Expose the `skin` parameter in `vesin.metatomic`

### DIFF
--- a/python/vesin/vesin/metatomic/_model.py
+++ b/python/vesin/vesin/metatomic/_model.py
@@ -48,6 +48,7 @@ def neighbor_lists_for_model(
         or not. If ``True``, this requires installing the ``vesin-torch`` package.
     :param check_consistency: whether to run additional checks on the neighbor lists
         validity
+    :param skin: the skin to use for the Verlet list in the NL calculation
     """
 
     if isinstance(model, AtomisticModel):
@@ -112,6 +113,7 @@ def compute_requested_neighbors(
         required when giving a raw model instead of a :py:class:`AtomisticModel`.
     :param check_consistency: whether to run additional checks on the neighbor lists
         validity
+    :param skin: the skin to use for the Verlet list in the NL calculation
     """
 
     if isinstance(model, AtomisticModel):
@@ -210,6 +212,7 @@ def compute_requested_neighbors_from_options(
     :param system_length_unit: unit of length used by the data in ``systems``
     :param check_consistency: whether to run additional checks on the neighbor lists
         validity
+    :param skin: the skin to use for the Verlet list in the NL calculation
     """
 
     warnings.warn(

--- a/python/vesin/vesin/metatomic/_model.py
+++ b/python/vesin/vesin/metatomic/_model.py
@@ -18,6 +18,7 @@ def neighbor_lists_for_model(
     model_length_unit: Optional[str] = None,
     torchscript: bool = False,
     check_consistency: bool = False,
+    skin: float = 2.0,
 ) -> List[NeighborList]:
     """
     Get a list of calculators, corresponding to the neighbor lists requested by the
@@ -78,6 +79,7 @@ def neighbor_lists_for_model(
                 system_length_unit,
                 torchscript=torchscript,
                 check_consistency=check_consistency,
+                skin=skin,
             )
         )
     return calculators
@@ -89,6 +91,7 @@ def compute_requested_neighbors(
     model: Union[AtomisticModel, ModelInterface],
     model_length_unit: Optional[str] = None,
     check_consistency: bool = False,
+    skin: float = 2.0,
 ):
     """
     Compute all neighbors lists requested by the ``model`` through
@@ -140,7 +143,7 @@ def compute_requested_neighbors(
     )
 
     _compute_requested_neighbors_from_options_impl(
-        systems, all_options, system_length_unit, check_consistency
+        systems, all_options, system_length_unit, check_consistency, skin
     )
 
 
@@ -190,6 +193,7 @@ def compute_requested_neighbors_from_options(
     options: List[NeighborListOptions],
     system_length_unit: str,
     check_consistency: bool,
+    skin: float = 2.0,
 ) -> None:
     """
     Compute all neighbors lists requested by the ``options``, and store them inside all
@@ -219,6 +223,7 @@ def compute_requested_neighbors_from_options(
         options=options,
         system_length_unit=system_length_unit,
         check_consistency=check_consistency,
+        skin=skin,
     )
 
 
@@ -227,6 +232,7 @@ def _compute_requested_neighbors_from_options_impl(
     options: List[NeighborListOptions],
     system_length_unit: str,
     check_consistency: bool,
+    skin: float,
 ) -> None:
     if not isinstance(systems, list):
         systems = [systems]
@@ -236,6 +242,7 @@ def _compute_requested_neighbors_from_options_impl(
             option,
             system_length_unit,
             check_consistency=check_consistency,
+            skin=skin,
         )
 
         for system in systems:

--- a/python/vesin/vesin/metatomic/_neighbors.py
+++ b/python/vesin/vesin/metatomic/_neighbors.py
@@ -23,6 +23,7 @@ except ImportError:
             periodic: Union[bool, torch.Tensor],
             quantities: str,
             copy: bool = True,
+            skin: float = 2.0,
         ) -> List[torch.Tensor]:
             raise ValueError("torchscript=True requires `vesin-torch` as a dependency")
 
@@ -42,6 +43,7 @@ class NeighborList:
         length_unit: str,
         torchscript: bool = False,
         check_consistency: bool = False,
+        skin: float = 2.0,
     ):
         """
         :param options: :py:class:`metatomic.torch.NeighborListOptions` defining the
@@ -92,6 +94,7 @@ class NeighborList:
             self._nl = NeighborListNumpy(
                 cutoff=self.options.engine_cutoff(self.length_unit),
                 full_list=self.options.full_list,
+                skin=skin,
             )
 
         # cached Labels

--- a/python/vesin/vesin/metatomic/_neighbors.py
+++ b/python/vesin/vesin/metatomic/_neighbors.py
@@ -53,6 +53,9 @@ class NeighborList:
             or not. If ``True``, this requires installing the ``vesin-torch`` package.
         :param check_consistency: whether to run additional checks on the neighbor list
             validity
+        :param skin: the skin to use for the Verlet list in the NL calculation. This is
+            only used when ``torchscript=False``, as the ``vesin-torch`` implementation
+            does not support the Verlet list.
 
         Example
         -------


### PR DESCRIPTION
Enable the use of the Verlet list in engines utilizing `vesin.metatomic`