### PR TITLE
docs: update ASE intersphinx URL to ase-lib.org

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -73,7 +73,7 @@ intersphinx_mapping = {
     "metatomic": ("https://docs.metatensor.org/metatomic/latest/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
+    "ase": ("https://ase-lib.org/", None),
 }
 
 html_theme = "furo"


### PR DESCRIPTION
ASE moved its documentation from `wiki.fysik.dtu.dk/ase` to **`ase-lib.org`**; the old URL now 302-redirects there. This points the `ase` intersphinx inventory directly at the new canonical location.

The docs CI builds with warnings-as-errors, and the inventory fetch via the old (redirecting) URL has started failing — e.g. on recent PRs:

```
WARNING: failed to reach any of the inventories ... intersphinx inventory
'https://wiki.fysik.dtu.dk/ase/objects.inv' not fetchable ... 'ase-lib.org' ...
build finished with problems, 1 warning (with warnings treated as errors).
```

One-line change in `docs/src/conf.py`. Independent of (and useful for) the ASE neighbour-list plugin PR #173, where this surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)